### PR TITLE
Wip/add landcover example

### DIFF
--- a/examples/item-landcover_Z_f_2019_cog.json
+++ b/examples/item-landcover_Z_f_2019_cog.json
@@ -1,181 +1,188 @@
 {
-    "id": "landcover_Z_f_2019_cog",
-    "bbox": [
-        -95.99531873393823,
-        29.07716802830657,
-        -94.29534689027045,
-        30.39936449861516
-    ],
-    "type": "Feature",
-    "links": [
-        {
-            "rel": "collection",
-            "type": "application/json",
-            "href": "https://staging-stac.delta-backend.com/collections/houston-landcover"
-        },
-        {
-            "rel": "parent",
-            "type": "application/json",
-            "href": "https://staging-stac.delta-backend.com/collections/houston-landcover"
-        },
-        {
-            "rel": "root",
-            "type": "application/json",
-            "href": "https://staging-stac.delta-backend.com/"
-        },
-        {
-            "rel": "self",
-            "type": "application/geo+json",
-            "href": "https://staging-stac.delta-backend.com/collections/houston-landcover/items/landcover_Z_f_2019_cog"
-        }
-    ],
-    "assets": {
-        "cog_default": {
-            "href": "s3://veda-data-store-staging/houston-landcover/landcover_Z_f_2019_cog.tif",
-            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-            "roles": [
-                "data",
-                "layer"
-            ],
-            "title": "Default COG Layer",
-            "description": "Cloud optimized default layer to display on map",
-            "raster:bands": [
-                {
-                    "scale": 1,
-                    "nodata": -999,
-                    "offset": 0,
-                    "sampling": "area",
-                    "data_type": "float32",
-                    "histogram": {
-                        "max": 95,
-                        "min": 11,
-                        "count": 11,
-                        "buckets": [
-                            92542,
-                            221312,
-                            3652,
-                            107193,
-                            11793,
-                            0,
-                            0,
-                            19862,
-                            249362,
-                            150800
-                        ]
-                    },
-                    "statistics": {
-                        "mean": 54.547851995759565,
-                        "stddev": 30.797947880218707,
-                        "maximum": 95,
-                        "minimum": 11,
-                        "valid_percent": 91.61461185651699
-                    }
-                }
-            ]
-        }
+  "id": "landcover_Z_f_2019_cog",
+  "bbox": [
+    -95.99531873393823,
+    29.07716802830657,
+    -94.29534689027045,
+    30.39936449861516
+  ],
+  "type": "Feature",
+  "links": [
+    {
+      "rel": "collection",
+      "type": "application/json",
+      "href": "https://staging-stac.delta-backend.com/collections/houston-landcover"
     },
-    "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [
-                    -95.99531873393823,
-                    29.07716802830657
-                ],
-                [
-                    -94.29534689027045,
-                    29.07716802830657
-                ],
-                [
-                    -94.29534689027045,
-                    30.39936449861516
-                ],
-                [
-                    -95.99531873393823,
-                    30.39936449861516
-                ],
-                [
-                    -95.99531873393823,
-                    29.07716802830657
-                ]
+    {
+      "rel": "parent",
+      "type": "application/json",
+      "href": "https://staging-stac.delta-backend.com/collections/houston-landcover"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://staging-stac.delta-backend.com/"
+    },
+    {
+      "rel": "self",
+      "type": "application/geo+json",
+      "href": "https://staging-stac.delta-backend.com/collections/houston-landcover/items/landcover_Z_f_2019_cog"
+    }
+  ],
+  "assets": {
+    "cog_default": {
+      "href": "s3://veda-data-store-staging/houston-landcover/landcover_Z_f_2019_cog.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "data",
+        "layer"
+      ],
+      "title": "Default COG Layer",
+      "description": "Cloud optimized default layer to display on map",
+      "raster:bands": [
+        {
+          "scale": 1,
+          "nodata": -999,
+          "offset": 0,
+          "sampling": "area",
+          "data_type": "float32",
+          "histogram": {
+            "max": 95,
+            "min": 11,
+            "count": 11,
+            "buckets": [
+              92542,
+              221312,
+              3652,
+              107193,
+              11793,
+              0,
+              0,
+              19862,
+              249362,
+              150800
             ]
+          },
+          "statistics": {
+            "mean": 54.547851995759565,
+            "stddev": 30.797947880218707,
+            "maximum": 95,
+            "minimum": 11,
+            "valid_percent": 91.61461185651699
+          }
+        }
+      ]
+    }
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -95.99531873393823,
+          29.07716802830657
+        ],
+        [
+          -94.29534689027045,
+          29.07716802830657
+        ],
+        [
+          -94.29534689027045,
+          30.39936449861516
+        ],
+        [
+          -95.99531873393823,
+          30.39936449861516
+        ],
+        [
+          -95.99531873393823,
+          29.07716802830657
         ]
-    },
-    "collection": "houston-landcover",
-    "properties": {
-        "datetime": "2019-01-01T00:00:00+00:00",
-        "proj:bbox": [
+      ]
+    ]
+  },
+  "collection": "houston-landcover",
+  "properties": {
+    "datetime": "2019-01-01T00:00:00+00:00",
+    "proj:bbox": [
+      -10686150,
+      3364710,
+      -10496910,
+      3533370
+    ],
+    "proj:epsg": 3395,
+    "proj:shape": [
+      5622,
+      6308
+    ],
+    "proj:geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
             -10686150,
-            3364710,
+            3364710
+          ],
+          [
+            -10496910,
+            3364710
+          ],
+          [
             -10496910,
             3533370
-        ],
-        "proj:epsg": 3395,
-        "proj:shape": [
-            5622,
-            6308
-        ],
-        "proj:geometry": {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [
-                        -10686150,
-                        3364710
-                    ],
-                    [
-                        -10496910,
-                        3364710
-                    ],
-                    [
-                        -10496910,
-                        3533370
-                    ],
-                    [
-                        -10686150,
-                        3533370
-                    ],
-                    [
-                        -10686150,
-                        3364710
-                    ]
-                ]
-            ]
-        },
-        "proj:transform": [
-            30,
-            0,
+          ],
+          [
             -10686150,
-            0,
-            -30,
-            3533370,
-            0,
-            0,
-            1
+            3533370
+          ],
+          [
+            -10686150,
+            3364710
+          ]
         ]
+      ]
     },
-    "stac_version": "1.0.0",
-    "stac_extensions": [
-        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
-        "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
-    ],
-    "virtual:assets": {
-        "default": {
-          "href": [ "#cog_default" ],
-          "title": "Default Visualization",
-          "processing:expression": [{
-            "format": "rescale",
-            "expression": "-215,215"
-          }, {
-            "format": "resampling",
-            "expression": "bilinear"
-          }, {
-            "format": "colormap_name",
-            "expression": "rdbu_r"
-          }, {
-            "format": "bidx",
-            "expression": 1
-          }]
+    "proj:transform": [
+      30,
+      0,
+      -10686150,
+      0,
+      -30,
+      3533370,
+      0,
+      0,
+      1
+    ]
+  },
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+  ],
+  "virtual:assets": {
+    "default": {
+      "href": [
+        "#cog_default"
+      ],
+      "title": "Default Visualization",
+      "processing:expression": [
+        {
+          "format": "rescale",
+          "expression": "-215,215"
+        },
+        {
+          "format": "resampling",
+          "expression": "bilinear"
+        },
+        {
+          "format": "colormap_name",
+          "expression": "rdbu_r"
+        },
+        {
+          "format": "bidx",
+          "expression": 1
         }
-      }    
+      ]
+    }
+  }
 }

--- a/examples/item-landcover_Z_f_2019_cog.json
+++ b/examples/item-landcover_Z_f_2019_cog.json
@@ -1,0 +1,181 @@
+{
+    "id": "landcover_Z_f_2019_cog",
+    "bbox": [
+        -95.99531873393823,
+        29.07716802830657,
+        -94.29534689027045,
+        30.39936449861516
+    ],
+    "type": "Feature",
+    "links": [
+        {
+            "rel": "collection",
+            "type": "application/json",
+            "href": "https://staging-stac.delta-backend.com/collections/houston-landcover"
+        },
+        {
+            "rel": "parent",
+            "type": "application/json",
+            "href": "https://staging-stac.delta-backend.com/collections/houston-landcover"
+        },
+        {
+            "rel": "root",
+            "type": "application/json",
+            "href": "https://staging-stac.delta-backend.com/"
+        },
+        {
+            "rel": "self",
+            "type": "application/geo+json",
+            "href": "https://staging-stac.delta-backend.com/collections/houston-landcover/items/landcover_Z_f_2019_cog"
+        }
+    ],
+    "assets": {
+        "cog_default": {
+            "href": "s3://veda-data-store-staging/houston-landcover/landcover_Z_f_2019_cog.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data",
+                "layer"
+            ],
+            "title": "Default COG Layer",
+            "description": "Cloud optimized default layer to display on map",
+            "raster:bands": [
+                {
+                    "scale": 1,
+                    "nodata": -999,
+                    "offset": 0,
+                    "sampling": "area",
+                    "data_type": "float32",
+                    "histogram": {
+                        "max": 95,
+                        "min": 11,
+                        "count": 11,
+                        "buckets": [
+                            92542,
+                            221312,
+                            3652,
+                            107193,
+                            11793,
+                            0,
+                            0,
+                            19862,
+                            249362,
+                            150800
+                        ]
+                    },
+                    "statistics": {
+                        "mean": 54.547851995759565,
+                        "stddev": 30.797947880218707,
+                        "maximum": 95,
+                        "minimum": 11,
+                        "valid_percent": 91.61461185651699
+                    }
+                }
+            ]
+        }
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -95.99531873393823,
+                    29.07716802830657
+                ],
+                [
+                    -94.29534689027045,
+                    29.07716802830657
+                ],
+                [
+                    -94.29534689027045,
+                    30.39936449861516
+                ],
+                [
+                    -95.99531873393823,
+                    30.39936449861516
+                ],
+                [
+                    -95.99531873393823,
+                    29.07716802830657
+                ]
+            ]
+        ]
+    },
+    "collection": "houston-landcover",
+    "properties": {
+        "datetime": "2019-01-01T00:00:00+00:00",
+        "proj:bbox": [
+            -10686150,
+            3364710,
+            -10496910,
+            3533370
+        ],
+        "proj:epsg": 3395,
+        "proj:shape": [
+            5622,
+            6308
+        ],
+        "proj:geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [
+                        -10686150,
+                        3364710
+                    ],
+                    [
+                        -10496910,
+                        3364710
+                    ],
+                    [
+                        -10496910,
+                        3533370
+                    ],
+                    [
+                        -10686150,
+                        3533370
+                    ],
+                    [
+                        -10686150,
+                        3364710
+                    ]
+                ]
+            ]
+        },
+        "proj:transform": [
+            30,
+            0,
+            -10686150,
+            0,
+            -30,
+            3533370,
+            0,
+            0,
+            1
+        ]
+    },
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+    ],
+    "virtual:assets": {
+        "default": {
+          "href": [ "#cog_default" ],
+          "title": "Default Visualization",
+          "processing:expression": [{
+            "format": "rescale",
+            "expression": "-215,215"
+          }, {
+            "format": "resampling",
+            "expression": "bilinear"
+          }, {
+            "format": "colormap_name",
+            "expression": "rdbu_r"
+          }, {
+            "format": "bidx",
+            "expression": 1
+          }]
+        }
+      }    
+}


### PR DESCRIPTION
@emmanuelmathot @vincentsarago @smohiudd it was proposed in the STAC sprint (see https://github.com/stac-extensions/web-map-links/issues/19) that this composite meta-extension could solve the needs of the proposed render extension. I think this makes sense but there are a few concerns I have:

1. communication - how do users of STAC and titiler know how to use this extension properly? It's still not entirely clear to me (as you will see in this PR) how to use this extension to satisfy the use case of rendering raster datasets via the titiler API.
2. currently the composite extension is on the item level - I'm not sure we need to hydrate all items with these values so could it also be at the collection level?
3. Right now the processing extension only allows for objects to be the value of the `processing:expression` and, as you see in this PR, what I think we need is a list.
